### PR TITLE
:arrow_up:  remove custom implementation to bypass warp-contracts bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "arweave": "1.11.4",
     "node-fetch": "2",
     "util": "^0.12.4",
-    "warp-contracts": "^1.1.6"
+    "warp-contracts": "^1.1.7"
   }
 }

--- a/src/community.ts
+++ b/src/community.ts
@@ -28,7 +28,6 @@ export default class Community {
   private feeAr: string = '0.000249005088';
 
   private arweave: Arweave;
-  private $arweave: Arweave; 
   private warp: Warp;
   private wallet!: JWKInterface | 'use_wallet';
   private walletAddress!: string;
@@ -61,12 +60,6 @@ export default class Community {
       this.warp = WarpWebFactory.memCachedBased(this.arweave).build();
     }
 
-    // clone arweave from original config
-    // because warp-contracts changes implementation of arweave.wallets.getBalance
-    // ending up throwing an error about active tx.
-    this.$arweave = Arweave.init({
-      ...this.arweave.getConfig().api
-    });
     this.getFees();
     this.events();
   }
@@ -757,7 +750,7 @@ export default class Community {
    */
   private async chargeFee(): Promise<{ target: string; winstonQty: string }> {
     await this.getWalletAddress();
-    const balance = await this.$arweave.wallets.getBalance(this.walletAddress);
+    const balance = await this.arweave.wallets.getBalance(this.walletAddress);
 
     if (+balance < +this.feeWinston) {
       throw new Error('Not enough balance.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,10 +3835,10 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.12"
 
-warp-contracts@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.1.6.tgz#8fba9d35662215dce3c14ce140bbc1b345847721"
-  integrity sha512-yjNA+bIMit16DxGX7ELmnOkzi1ppDkCM7xdRbx+dDLujBIEOBVIygMAooQgn+QerEpS8vzyWLtRlNLhrPwZm2Q==
+warp-contracts@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.1.7.tgz#43635d0e963af9a89b001b7f350ea5257eb787d8"
+  integrity sha512-6KYlzESNG9S4ukkb4BMAqqldoUOY08xkGXPndBOQ01DhB2swnROYu/nI7id4HIVj0aaOaIdK3HYgZBPxsbFVaA==
   dependencies:
     "@assemblyscript/loader" "^0.19.23"
     "@idena/vrf-js" "^1.0.1"


### PR DESCRIPTION
warp-contracts bug of overriding the `arweave.wallets.getBalance` method has been fixed, so custom implementation to bypass is no longer needed.

see https://github.com/warp-contracts/warp/issues/187